### PR TITLE
deps: updates wazero to 1.0.0-pre.1

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,8 +1,8 @@
 module wasmhook
 
-go 1.17
+go 1.18
 
-require github.com/tetratelabs/wazero v0.0.0-20220623044246-3b4544ee4845
+require github.com/tetratelabs/wazero v1.0.0-pre.1
 
 require (
 	github.com/CosmWasm/tinyjson v0.9.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -236,8 +236,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220623044246-3b4544ee4845 h1:QAI/xayvR61WbiAvOUpHDWAMlzHEG7upUW/RKJxUPUw=
-github.com/tetratelabs/wazero v0.0.0-20220623044246-3b4544ee4845/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v1.0.0-pre.1 h1:bUZ4vf21c36RmgA3enNOlLgPElEVDYoRJJ9+McRGF6Q=
+github.com/tetratelabs/wazero v1.0.0-pre.1/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/src/loadedmodule.go
+++ b/src/loadedmodule.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 type LoadedModule struct {
@@ -17,8 +17,8 @@ type LoadedModule struct {
 }
 
 func NewLoadedModule(wasmBytes []byte) LoadedModule {
-	r := wazero.NewRuntime()
 	ctx := context.Background()
+	r := wazero.NewRuntime(ctx)
 	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
 		log.Panicln(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.1](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.1).

A new pre-release will happen at least once each month until 1.0 in February 2023.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.